### PR TITLE
Deprecate old helm-chart & versions

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -463,7 +463,7 @@ entries:
   - apiVersion: v2
     appVersion: 0.2.0
     created: "2023-01-06T17:25:43.340333606Z"
-    description: A Kubernetes ingress controller built using ngrok.
+    description: "[DEPRECATED] A Kubernetes ingress controller built using ngrok."
     digest: bb807b0d1944bab72dca7d0845c92c32b2d49dd139195ac8958041573422a406
     home: https://ngrok.com
     icon: https://blog.ngrok.com/_next/image?url=%2Fassets%2Fblog%2Fplaceholder.png&w=1920&q=75
@@ -482,7 +482,7 @@ entries:
   - apiVersion: v2
     appVersion: 0.2.0
     created: "2022-12-28T19:41:20.480900181Z"
-    description: A Kubernetes ingress controller built using ngrok.
+    description: "[DEPRECATED] A Kubernetes ingress controller built using ngrok."
     digest: 801ce269d7210627c20f00afbac6595a355b2892790119a89c6b3d5ccf4d90eb
     home: https://ngrok.com
     icon: https://blog.ngrok.com/_next/image?url=%2Fassets%2Fblog%2Fplaceholder.png&w=1920&q=75
@@ -501,7 +501,7 @@ entries:
   - apiVersion: v2
     appVersion: 0.2.0
     created: "2022-12-27T20:22:39.74679125Z"
-    description: A Kubernetes ingress controller built using ngrok.
+    description: "[DEPRECATED] A Kubernetes ingress controller built using ngrok."
     digest: 9aaeab6595aa69b570aa7b8995fffe4a0de0e717fb55a289518fa827e114019f
     home: https://ngrok.com
     icon: https://blog.ngrok.com/_next/image?url=%2Fassets%2Fblog%2Fplaceholder.png&w=1920&q=75
@@ -520,7 +520,7 @@ entries:
   - apiVersion: v2
     appVersion: 0.1.0
     created: "2022-12-19T22:15:05.27915866Z"
-    description: A Kubernetes ingress controller built using ngrok.
+    description: "[DEPRECATED] A Kubernetes ingress controller built using ngrok."
     digest: 586bd9f5db6aa52c5898023e439d70dd0290d86588b53df2de128aa41ce799e3
     home: https://ngrok.com
     icon: https://blog.ngrok.com/_next/image?url=%2Fassets%2Fblog%2Fplaceholder.png&w=1920&q=75
@@ -539,7 +539,7 @@ entries:
   - apiVersion: v2
     appVersion: 0.1.0
     created: "2022-10-18T19:14:54.763630215Z"
-    description: A Kubernetes ingress controller built using ngrok.
+    description: "[DEPRECATED] A Kubernetes ingress controller built using ngrok."
     digest: 4551cde6c5465355a6c881a48c7b3a3537f766817b007d98b8da9976640b4fe4
     home: https://ngrok.com
     icon: https://blog.ngrok.com/_next/image?url=%2Fassets%2Fblog%2Fplaceholder.png&w=1920&q=75
@@ -558,7 +558,7 @@ entries:
   - apiVersion: v2
     appVersion: 0.1.0
     created: "2022-10-10T21:06:04.341631508Z"
-    description: A Kubernetes ingress controller built using Ngrok.
+    description: "[DEPRECATED] A Kubernetes ingress controller built using Ngrok."
     digest: ef73c580abc111798081a36bc154f0590b58b0601442c1a2602647dc313f4944
     home: https://ngrok.com
     icon: https://blog.ngrok.com/_next/image?url=%2Fassets%2Fblog%2Fplaceholder.png&w=1920&q=75
@@ -577,7 +577,7 @@ entries:
   - apiVersion: v2
     appVersion: 0.1.0
     created: "2022-10-06T20:32:21.494848009Z"
-    description: A Kubernetes ingress controller built using Ngrok.
+    description: "[DEPRECATED] A Kubernetes ingress controller built using Ngrok."
     digest: c9b93a32917c45d6abcebec587441672f28dfbf673e6212c1b91e7f9eadddaf7
     home: https://ngrok.com
     icon: https://blog.ngrok.com/_next/image?url=%2Fassets%2Fblog%2Fplaceholder.png&w=1920&q=75


### PR DESCRIPTION
Deprecate the old helm chart by deprecating all of its versions. Eventually we'll need to do the same for the `kubernetes-ingress-controller` chart once we release a `ngrok-operator` helm chart.