### PR TITLE
feat: Add a simple index.html for charts.ngrok.com

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*               @ngrok/ngrok-operators

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.exclude": {
+        "**/*.tgz": true,
+        "**/*.tgz.prov": true,
+    }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="0; url=https://ngrok.com/docs/k8s/installation/install/">
+        <script type="text/javascript">
+            window.location.href = "https://ngrok.com/docs/k8s/installation/install/";
+        </script>
+        <title>Page Redirection</title>
+    </head>
+    <body>
+        <p>If you are not redirected automatically, follow the <a href="https://ngrok.com/docs/k8s/installation/install/">link to the new page</a>.</p>
+    </body>
+</html>


### PR DESCRIPTION
Adds a simple index.html so that users don't get the GH 404 page if they go to https://charts.ngrok.com. Instead, they should automatically get redirected to the ngrok docs for installing the ngrok operator. We may spruce this up over time to include versions of the ngrok operator and provide a list of artifacts hosted. For now, though, this is better than the 404 page.